### PR TITLE
Handling events of promt and prompt version deletion

### DIFF
--- a/api/v1/prompt.py
+++ b/api/v1/prompt.py
@@ -13,6 +13,7 @@ from ...utils.prompt_utils_legacy import (
     prompts_update_name,
     prompts_update_prompt
 )
+from ...utils.publish_utils import fire_prompt_deleted_event
 
 from tools import api_tools, auth, config as c, db
 
@@ -91,6 +92,8 @@ class PromptLibAPI(api_tools.APIModeHandler):
     def delete(self, project_id, prompt_id):
         with db.with_project_schema_session(project_id) as session:
             if prompt := session.query(Prompt).get(prompt_id):
+                prompt_data = prompt.to_json()
+                fire_prompt_deleted_event(project_id, prompt_data)
                 session.delete(prompt)
                 session.commit()
                 return '', 204

--- a/events/publish.py
+++ b/events/publish.py
@@ -1,0 +1,55 @@
+from pylon.core.tools import log, web
+from tools import db, VaultClient
+
+from ..utils.publish_utils import (
+    close_private_version, 
+    close_private_prompt,
+    delete_public_prompt,
+    delete_public_version
+)
+
+
+class Event:
+    @web.event("prompt_deleted")
+    def handler(self, context, event, payload: dict):
+        secrets = VaultClient().get_all_secrets()
+        public_id = secrets.get("ai_project_id")
+        
+        if not public_id:
+            log.warning("No public project is not set and post prompt deletion event is skipped")
+            return
+
+        project_id = payload.get('project_id')
+        version_data = payload.get('version_data')
+        prompt_data = payload.get('prompt_data')
+        
+        if not int(project_id) == int(public_id):
+            # deletion in private project, then
+            with db.with_project_schema_session(public_id) as session:
+                prompt_owner_id = prompt_data['owner_id']
+                prompt_id = prompt_data['id']
+                if version_data:
+                    # version is deleted, then
+                    version_name = version_data['name']
+                    delete_public_version(prompt_owner_id, prompt_id, version_name, session)
+                    return session.commit()
+                
+                # private prompt is deleted, then
+                delete_public_prompt(prompt_owner_id, prompt_id, session)
+                return session.commit()
+
+        # deletion in public
+        shared_id = prompt_data['shared_id']
+        shared_owner_id = prompt_data['shared_owner_id']
+        
+        with db.with_project_schema_session(shared_owner_id) as session:
+            if version_data:
+                # version is deleted
+                version_name = version_data['name']
+                close_private_version(shared_owner_id, shared_id, version_name, session)
+                return session.commit()
+            
+            # prompt is deleted
+            close_private_prompt(shared_owner_id, shared_id, session)
+            return session.commit()
+ 


### PR DESCRIPTION
Changes:
1. If a private prompt is deleted, then the public prompt and its version are deleted
2. If a private version is deleted, then the public version is deleted
3. if a public prompt is deleted, then the private prompt's versions' statuses are set to draft
4. if a public version is deleted, then the private prompt version is set to draft
5. Fixed the bug of PublishUtils.check_already_published()
6. Another check for publishing a prompt version from the public project is added. If so, then an error is returned