### PR TITLE
Fixes in prompt deletion events and unpublish feature

### DIFF
--- a/api/v1/prompt.py
+++ b/api/v1/prompt.py
@@ -94,7 +94,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
             try:
                 is_public, _ = is_public_project(project_id)
                 if is_public:
-                    return "Deleting from public project is prohibited", 403
+                    return {"ok": False, "error": "Deleting from public project is prohibited"}, 403
             except Exception:
                 log.warning('Public project is not set so any prompt can be deleted')
                 pass
@@ -105,7 +105,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
                 session.delete(prompt)
                 session.commit()
                 return '', 204
-            return '', 404
+            return {"ok": False, "error": "Prompt is not found"}, 404
 
 
 class API(api_tools.APIBase):

--- a/api/v1/prompt.py
+++ b/api/v1/prompt.py
@@ -13,7 +13,7 @@ from ...utils.prompt_utils_legacy import (
     prompts_update_name,
     prompts_update_prompt
 )
-from ...utils.publish_utils import fire_prompt_deleted_event
+from ...utils.publish_utils import fire_prompt_deleted_event, is_public_project
 
 from tools import api_tools, auth, config as c, db
 
@@ -91,6 +91,9 @@ class PromptLibAPI(api_tools.APIModeHandler):
     #     }})
     def delete(self, project_id, prompt_id):
         with db.with_project_schema_session(project_id) as session:
+            is_public, _ = is_public_project(project_id)
+            if is_public:
+                return "Deleting from public project is prohibited", 403
             if prompt := session.query(Prompt).get(prompt_id):
                 prompt_data = prompt.to_json()
                 fire_prompt_deleted_event(project_id, prompt_data)

--- a/api/v1/prompt.py
+++ b/api/v1/prompt.py
@@ -91,9 +91,14 @@ class PromptLibAPI(api_tools.APIModeHandler):
     #     }})
     def delete(self, project_id, prompt_id):
         with db.with_project_schema_session(project_id) as session:
-            is_public, _ = is_public_project(project_id)
-            if is_public:
-                return "Deleting from public project is prohibited", 403
+            try:
+                is_public, _ = is_public_project(project_id)
+                if is_public:
+                    return "Deleting from public project is prohibited", 403
+            except Exception:
+                log.warning('Public project is not set so any prompt can be deleted')
+                pass
+
             if prompt := session.query(Prompt).get(prompt_id):
                 prompt_data = prompt.to_json()
                 fire_prompt_deleted_event(project_id, prompt_data)

--- a/api/v1/publish.py
+++ b/api/v1/publish.py
@@ -1,12 +1,17 @@
 from ...utils.constants import PROMPT_LIB_MODE
 from ...utils.publish_utils import Publishing
 from tools import api_tools
+from pylon.core.tools import log
 
 
 class PromptLibAPI(api_tools.APIModeHandler):
     def post(self, project_id: int, version_id: int, **kwargs):
-        result = Publishing(project_id, version_id).publish()
-        
+        try:
+            result = Publishing(project_id, version_id).publish()
+        except Exception as e:
+            log.error(e)
+            return {"ok": False, "error": str(e)}, 400
+         
         if not result['ok']:
             code = result.pop('error_code', 400)
             return result, code

--- a/api/v1/unpublish.py
+++ b/api/v1/unpublish.py
@@ -1,0 +1,31 @@
+from ...utils.constants import PROMPT_LIB_MODE
+from ...utils.publish_utils import unpublish
+from tools import api_tools, auth
+from pylon.core.tools import log
+
+
+class PromptLibAPI(api_tools.APIModeHandler):
+    def delete(self, version_id: int, **kwargs):
+        try:
+            current_user = auth.current_user().get("id")
+            result = unpublish(current_user, version_id)
+        except Exception as e:
+            log.error(e)
+            return {"ok": False, "error": str(e)}, 400
+         
+        if not result['ok']:
+            code = result.pop('error_code', 400)
+            return result, code
+        #
+        # prompt_version = result['prompt_version']
+        return result, 200
+
+
+class API(api_tools.APIBase):
+    url_params = api_tools.with_modes([
+        '<int:version_id>',
+    ])
+
+    mode_handlers = {
+        PROMPT_LIB_MODE: PromptLibAPI
+    }

--- a/events/collections.py
+++ b/events/collections.py
@@ -1,10 +1,55 @@
 from pylon.core.tools import log, web
-
+from collections import defaultdict
 from tools import db
-from ..models.all import Collection
+from ..models.all import Collection, Prompt
 from copy import deepcopy
 
+
 class Event:
+
+    @web.event("prompt_lib_collection_updated")
+    def handle_collection_updated(self, context, event, payload: dict):
+        added_prompts = payload['added_prompts']
+        removed_prompts = payload['removed_prompts']
+        collection_data = payload['collection_data']
+
+        # add collection to prompts:
+        added_prompts: dict = group_by_project_id(added_prompts, data_type="tuple")
+        for project_id, prompt_ids in added_prompts.items():
+            with db.with_project_schema_session(project_id) as session:
+                add_collection_to_prompts(prompt_ids, collection_data, session)
+                session.commit()
+        
+        # remove collection from prompts
+        removed_prompts: dict = group_by_project_id(removed_prompts, data_type="tuple")
+        for project_id, prompt_ids in removed_prompts.items():
+            with db.with_project_schema_session(project_id) as session:
+                delete_collection_from_prompts(prompt_ids, collection_data, session)
+                session.commit()
+
+
+    @web.event("prompt_lib_collection_deleted")
+    def handle_collection_deleted(self, context, event, payload: dict):
+        collection_data = payload
+        # group by prompt data        
+        prompts = group_by_project_id(collection_data['prompts'])
+        for owner_id, prompt_ids in prompts.items():
+            with db.with_project_schema_session(owner_id) as session:
+                delete_collection_from_prompts(prompt_ids, collection_data, session)
+                session.commit()
+
+
+    @web.event("prompt_lib_collection_added")
+    def handle_collection_deleted(self, context, event, payload: dict):
+        # group by prompt data        
+        collection_data = payload
+        prompts = group_by_project_id(collection_data['prompts'])
+        for owner_id, prompt_ids in prompts.items():
+            with db.with_project_schema_session(owner_id) as session:
+                add_collection_to_prompts(prompt_ids, collection_data, session)
+                session.commit()
+
+
     @web.event("prune_collection_prompts")
     def prune_collection_prompts(self, context, event, payload: dict):
         existing_prompts = payload.get('existing_prompts')
@@ -25,3 +70,37 @@ class Event:
             ]
             collection.prompts = clean_prompts
             session.commit()
+
+
+def group_by_project_id(data, data_type='dict'):
+    prompts = defaultdict(list)
+    group_field = "owner_id" if not data_type == "tuple" else 0
+    data_field = "id" if not data_type == "tuple" else 1
+    for entity in data:
+        prompts[entity[group_field]].append(entity[data_field])
+    return prompts
+
+
+def delete_collection_from_prompts(prompt_ids: list, collection_data: dict, session):
+    col_owner_id = collection_data['owner_id']
+    col_id = collection_data['id']
+    prompts = session.query(Prompt).filter(Prompt.id.in_(prompt_ids)).all()
+    for prompt in prompts:
+        new_data = [
+            deepcopy(collection) for collection in prompt.collections
+            if collection['owner_id'] != col_owner_id or collection['id'] != col_id   
+        ]
+        prompt.collections = new_data
+
+
+def add_collection_to_prompts(prompt_ids: list, collection_data: dict, session):
+    col_owner_id = collection_data['owner_id']
+    col_id = collection_data['id']
+    prompts = session.query(Prompt).filter(Prompt.id.in_(prompt_ids)).all()
+    for prompt in prompts:
+        new_data: list = deepcopy(prompt.collections)
+        new_data.append({
+            "owner_id": col_owner_id,
+            "id": col_id
+        })
+        prompt.collections = new_data

--- a/events/publish.py
+++ b/events/publish.py
@@ -74,8 +74,11 @@ class Event:
                         break
                 payload['status'] = new_status
                 sleep(60)
-                public_version.status = new_status
-                session.commit()
+                try:
+                    public_version.status = new_status
+                    session.commit()
+                except:
+                    return log.info("The version is already stale")
                 return context.event_manager.fire_event('prompt_public_version_status_change', payload)
                 
             set_status(

--- a/events/publish.py
+++ b/events/publish.py
@@ -1,6 +1,6 @@
 from pylon.core.tools import log, web
 
-from tools import db, VaultClient
+from tools import db
 
 from sqlalchemy.orm import joinedload
 from ..models.all import PromptVersion
@@ -10,60 +10,51 @@ from ..utils.publish_utils import set_status
 
 from time import sleep
 from ..utils.publish_utils import (
-    close_private_version,
-    close_private_prompt,
-    delete_public_prompt,
-    delete_public_version
+    close_private_version, 
+    delete_public_prompt_versions,
+    delete_public_version,
 )
 
 
 class Event:
-    @web.event("prompt_deleted")
+    @web.event("public_prompt_version_deleted")
     def handler(self, context, event, payload: dict):
-        secrets = VaultClient().get_all_secrets()
-        public_id = secrets.get("ai_project_id")
-
-        if not public_id:
-            log.warning("No public project is not set and post prompt deletion event is skipped")
-            return
-
-        project_id = payload.get('project_id')
-        version_data = payload.get('version_data')
-        prompt_data = payload.get('prompt_data')
-
-        if not int(project_id) == int(public_id):
-            # deletion in private project, then
-            with db.with_project_schema_session(public_id) as session:
-                prompt_owner_id = prompt_data['owner_id']
-                prompt_id = prompt_data['id']
-                if version_data:
-                    # version is deleted, then
-                    version_name = version_data['name']
-                    delete_public_version(prompt_owner_id, prompt_id, version_name, session)
-                    return session.commit()
-
-                # private prompt is deleted, then
-                delete_public_prompt(prompt_owner_id, prompt_id, session)
-                return session.commit()
-
-        # deletion in public
-        shared_id = prompt_data['shared_id']
-        shared_owner_id = prompt_data['shared_owner_id']
-
+        version_data = payload['version_data']
+        shared_owner_id = version_data['shared_owner_id']
         with db.with_project_schema_session(shared_owner_id) as session:
-            if version_data:
-                # version is deleted
-                version_name = version_data['name']
-                close_private_version(shared_owner_id, shared_id, version_name, session)
-                return session.commit()
-
-            # prompt is deleted
-            close_private_prompt(shared_owner_id, shared_id, session)
+            shared_id = version_data['shared_id']
+            close_private_version(shared_owner_id, shared_id, session)
             return session.commit()
+        
+
+    @web.event("private_prompt_version_deleted")
+    def handler(self, context, event, payload: dict):
+        version_data = payload['version_data']
+        prompt_data = payload['prompt_data']
+        public_id = payload['public_id']
+        #
+        with db.with_project_schema_session(int(public_id)) as session:
+            shared_owner_id = prompt_data['owner_id']
+            shared_id = version_data['id']
+            delete_public_version(shared_owner_id, shared_id, session)
+            return session.commit() 
+
+
+    @web.event("private_prompt_deleted")
+    def handler(self, context, event, payload: dict):
+        prompt_data = payload['prompt_data']
+        public_id = payload['public_id']
+        #
+        with db.with_project_schema_session(public_id) as session:
+            prompt_owner_id = prompt_data['owner_id']
+            prompt_id = prompt_data['id']
+            delete_public_prompt_versions(prompt_owner_id, prompt_id, session)
+            return session.commit()
+
 
     @web.event('prompt_public_version_status_change')
     def handle_on_moderation(self, context, event, payload: dict) -> None:
-        log.info(f'EVEnt {payload}')
+        log.info(f'Event {payload}')
 
         public_project_id = payload['public_project_id']
         public_version_id = payload['public_version_id']
@@ -92,3 +83,5 @@ class Event:
                 public_version.status = new_status
                 session.commit()
                 context.event_manager.fire_event('prompt_public_version_status_change', payload)
+
+ 

--- a/events/publish.py
+++ b/events/publish.py
@@ -55,23 +55,17 @@ class Event:
     @web.event('prompt_public_version_status_change')
     def handle_on_moderation(self, context, event, payload: dict) -> None:
         log.info(f'Event {payload}')
-
         public_project_id = payload['public_project_id']
         public_version_id = payload['public_version_id']
         status = payload['status']
+
         with db.with_project_schema_session(public_project_id) as session:
             public_version: PromptVersion = session.query(PromptVersion).options(
                 joinedload(PromptVersion.prompt)
             ).filter(
                 PromptVersion.id == public_version_id,
             ).first()
-            set_status(
-                project_id=public_version.prompt.shared_owner_id,
-                # prompt_version_id=public_version.prompt.shared_id,
-                prompt_version_name_or_id=public_version.name,
-                status=status
-            )
-
+            
             if status == PromptVersionStatus.on_moderation:
                 new_status = PromptVersionStatus.published
                 for i in public_version.tags:
@@ -82,6 +76,11 @@ class Event:
                 sleep(60)
                 public_version.status = new_status
                 session.commit()
-                context.event_manager.fire_event('prompt_public_version_status_change', payload)
-
- 
+                return context.event_manager.fire_event('prompt_public_version_status_change', payload)
+                
+            set_status(
+                project_id=public_version.prompt.shared_owner_id,
+                # prompt_version_id=public_version.prompt.shared_id,
+                prompt_version_name_or_id=public_version.name,
+                status=status
+            )

--- a/models/all.py
+++ b/models/all.py
@@ -26,6 +26,7 @@ class Prompt(db_tools.AbstractBaseMixin, db.Base):
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
     shared_owner_id: Mapped[int] = mapped_column(Integer, nullable=True)
     shared_id: Mapped[int] = mapped_column(Integer, nullable=True)
+    collections: Mapped[list] = mapped_column(JSON, nullable=True, default=list)
 
     def get_latest_version(self):
         return next(version for version in self.versions if version.name == 'latest')

--- a/models/all.py
+++ b/models/all.py
@@ -34,6 +34,7 @@ class Prompt(db_tools.AbstractBaseMixin, db.Base):
 class PromptVersion(db_tools.AbstractBaseMixin, db.Base):
     __tablename__ = 'prompt_versions'
     __table_args__ = (
+        UniqueConstraint('shared_owner_id', 'shared_id', name='_version_shared_origin'),
         UniqueConstraint('prompt_id', 'name', name='_prompt_name_uc'),
         {'schema': c.POSTGRES_TENANT_SCHEMA},
     )
@@ -56,6 +57,9 @@ class PromptVersion(db_tools.AbstractBaseMixin, db.Base):
     model_settings: Mapped[dict] = mapped_column(JSON, nullable=True)
     embedding_settings: Mapped[dict] = mapped_column(JSON, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+    # reference fields to origin 
+    shared_owner_id: Mapped[int] = mapped_column(Integer, nullable=True)
+    shared_id: Mapped[int] = mapped_column(Integer, nullable=True)
 
 
 class PromptVariable(db_tools.AbstractBaseMixin, db.Base):

--- a/models/pd/base.py
+++ b/models/pd/base.py
@@ -68,6 +68,9 @@ class PromptVersionBaseModel(BaseModel):
     embedding_settings: Optional[dict]  # todo: create model for this field
     type: PromptVersionType
     prompt_id: Optional[int]
+    shared_id: Optional[int]
+    shared_owner_id: Optional[int]
+
 
     class Config:
         orm_mode = True

--- a/models/pd/detail.py
+++ b/models/pd/detail.py
@@ -39,6 +39,7 @@ class PromptDetailModel(PromptBaseModel):
     versions: List[PromptVersionListModel]
     version_details: Optional[PromptVersionDetailModel]
     created_at: datetime
+    collections: Optional[list]
 
 class PublishedPromptDetailModel(PromptDetailModel):
 

--- a/utils/collections.py
+++ b/utils/collections.py
@@ -68,11 +68,18 @@ def list_collections(project_id: int, args=None):
 
 def delete_collection(project_id: int, collection_id: int):
     with db.with_project_schema_session(project_id) as session:
-        if prompt := session.query(Collection).get(collection_id):
-            session.delete(prompt)
+        if collection := session.query(Collection).get(collection_id):
+            collection_data = collection.to_json()
+            session.delete(collection)
             session.commit()
+            fire_collection_deleted_event(collection_data)
             return True
     return False
+
+def fire_collection_deleted_event(collection_data: dict):
+    rpc_tools.EventManagerMixin().event_manager.fire_event(
+        'prompt_lib_collection_deleted', collection_data
+    )
 
 
 def update_collection(context, project_id: int, collection_id: int, data: dict):
@@ -87,13 +94,46 @@ def update_collection(context, project_id: int, collection_id: int, data: dict):
                         f"User doesn't have access to project '{owner_id}'"
                     )
 
+            # snapshoting old state
+            old_state = collection.to_json()
+
             for field, value in data.items():
                 if hasattr(collection, field):
                     setattr(collection, field, value)
-
             session.commit()
+
+            fire_collection_updated_event(old_state, data)            
             return get_detail_collection(collection)
         return None
+
+
+def fire_collection_updated_event(old_state: dict, collection_payload: dict):
+    if 'prompts' not in collection_payload:
+        return
+    
+    # old state map
+    old_state_tuple_set = set()
+    for prompt in old_state['prompts']:
+        old_state_tuple_set.add((prompt['owner_id'], prompt['id']))
+
+    # new state map
+    new_state_tuple_set = set()
+    for prompt in collection_payload['prompts']:
+        new_state_tuple_set.add((prompt['owner_id'], prompt['id']))
+    
+    removed_prompts = old_state_tuple_set - new_state_tuple_set
+    added_prompts = new_state_tuple_set - old_state_tuple_set
+
+    rpc_tools.EventManagerMixin().event_manager.fire_event(
+        'prompt_lib_collection_updated', {
+            "removed_prompts": removed_prompts,
+            "added_prompts": added_prompts,
+            "collection_data": {
+                "owner_id": old_state['owner_id'],
+                "id": old_state['id']
+            }
+        }
+    )
 
 
 def get_collection(project_id: int, collection_id: int):
@@ -163,8 +203,14 @@ def create_collection(context, project_id: int, data):
         collection = Collection(**collection.dict())
         session.add(collection)
         session.commit()
+        fire_collection_created_event(collection.to_json())
         return get_detail_collection(collection)
 
+
+def fire_collection_created_event(collection_data: dict):
+    rpc_tools.EventManagerMixin().event_manager.fire_event(
+        'prompt_lib_collection_added', collection_data
+    )
 
 def add_prompt_to_collection(collection, prompt_data: PromptIds):
     prompts_list: List = copy.deepcopy(collection.prompts)
@@ -183,6 +229,26 @@ def remove_prompt_from_collection(collection, prompt_data: PromptIds):
     return get_detail_collection(collection)
 
 
+def fire_patch_collection_event(old_state, operartion, prompt_data):
+    if operartion == CollectionPatchOperations.add:
+        removed_prompts = tuple()
+        added_prompts = [(prompt_data.owner_id, prompt_data.id)]
+    else:
+        added_prompts = tuple()
+        removed_prompts = [(prompt_data.owner_id, prompt_data.id)]
+
+    rpc_tools.EventManagerMixin().event_manager.fire_event(
+        'prompt_lib_collection_updated', {
+            "removed_prompts": removed_prompts,
+            "added_prompts": added_prompts,
+            "collection_data": {
+                "owner_id": old_state['owner_id'],
+                "id": old_state['id']
+            }
+        }
+    )
+
+
 def patch_collection(context, project_id, collection_id, data: CollectionPatchModel):
     op_map = {
         CollectionPatchOperations.add: add_prompt_to_collection,
@@ -197,7 +263,6 @@ def patch_collection(context, project_id, collection_id, data: CollectionPatchMo
                 f"Prompt '{prompt_data.id}' in project '{prompt_data.owner_id}' doesn't exist"
             )
 
-
     with db.with_project_schema_session(project_id) as session:
         if collection := session.query(Collection).get(collection_id):
             if not check_prompts_addability(context, prompt_data.owner_id, collection.author_id):
@@ -206,6 +271,10 @@ def patch_collection(context, project_id, collection_id, data: CollectionPatchMo
                 )
 
             result = op_map[data.operation](collection, prompt_data)
+            collection_data = collection.to_json()
             session.commit()
+            fire_patch_collection_event(
+                collection_data, data.operation, prompt_data
+            )
             return result
         return None

--- a/utils/publish_utils.py
+++ b/utils/publish_utils.py
@@ -58,7 +58,7 @@ class Publishing(rpc_tools.EventManagerMixin):
         try:
             return int(secrets['ai_project_id'])
         except (KeyError, ValueError):
-            raise Exception("Public project doesn't exists or ai_project_id is not set in secrets")
+            raise Exception("Public project doesn't exist")
 
     def __jsonify_relationships(self, items):
         result = []
@@ -198,11 +198,10 @@ class Publishing(rpc_tools.EventManagerMixin):
                 'public_version_id': self.public_version_id,
                 'status': status
             })
+        
+        # set status of private prompt version
+        result = set_status(self.original_project, self.original_version, status)
         return result
-
-        # # set status of private prompt version
-        # result = set_status(self.original_project, self.original_version, status)
-        # return result
 
     def retrieve_private_prompt(self):
         with db.with_project_schema_session(self.original_project) as session:


### PR DESCRIPTION
**Prompt, versions deletion event's fixes:**
    1. Publishing prompt version from the public project is changing its status to moderation
    2. Disabling  public prompt deletion
    3. Adding two shared_* fields to version
    4. Changing version deletion events such that shared_* fields are used to find the related version
    5. Seperating prompts' deletion events
   
**Other Fixes:**
    1. Fixed bug in setting the status of public and private versions
    2. Handled exceptions when the public project doesn't exist
    3. Failure responses of version deletion have changed
    4. Prompt detail API contains collections field
  
**Unpublish feature**
 We can unpublish prompt versions if it is not a draft or rejected and we published it
