### PR TITLE
Feature: publishing collections

### DIFF
--- a/api/v1/collection.py
+++ b/api/v1/collection.py
@@ -50,9 +50,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         try:
             payload = request.get_json()
             CollectionUpdateModel.validate(payload)
-            result = update_collection(
-                self.module.context, project_id, collection_id, payload
-            )
+            result = update_collection(project_id, collection_id, payload)
             if not result:
                 return {"error": f"No collection found with id '{collection_id}'"}, 404
             return result, 200
@@ -72,9 +70,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         try:
             payload = request.get_json()
             collection_data = CollectionPatchModel.validate(payload)
-            result = patch_collection(
-                self.module.context, project_id, collection_id, collection_data
-            )
+            result = patch_collection(project_id, collection_id, collection_data)
             if not result:
                 return {"error": f"No collection found with id '{collection_id}'"}, 404
             return result, 200

--- a/api/v1/collections.py
+++ b/api/v1/collections.py
@@ -61,7 +61,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         data["owner_id"], data["author_id"] = project_id, author_id
 
         try:
-            result = create_collection(self.module.context, project_id, data)
+            result = create_collection(project_id, data)
             return result, 201
         except ValidationError as e:
             return e.errors(), 400

--- a/api/v1/publish_collection.py
+++ b/api/v1/publish_collection.py
@@ -1,0 +1,31 @@
+from ...utils.constants import PROMPT_LIB_MODE
+from ...utils.collections import CollectionPublishing
+from tools import api_tools
+from pylon.core.tools import log
+
+
+class PromptLibAPI(api_tools.APIModeHandler):
+    def post(self, project_id: int, collection_id: int, **kwargs):
+        try:
+            result = CollectionPublishing(project_id, collection_id).publish()
+        except Exception as e:
+            log.error(e)
+            return {"ok": False, "error": str(e)}, 400
+         
+        if not result['ok']:
+            code = result.pop('error_code', 400)
+            return result, code
+        #
+        prompt_version = result['new_collection']
+        return prompt_version, 200
+
+
+class API(api_tools.APIBase):
+    url_params = api_tools.with_modes([
+        '<int:project_id>',
+        '<int:project_id>/<int:collection_id>',
+    ])
+
+    mode_handlers = {
+        PROMPT_LIB_MODE: PromptLibAPI
+    }

--- a/events/collections.py
+++ b/events/collections.py
@@ -2,7 +2,10 @@ from pylon.core.tools import log, web
 from collections import defaultdict
 from tools import db
 from ..models.all import Collection, Prompt
+from ..models.enums.all import CollectionPatchOperations
 from copy import deepcopy
+from ..utils.collections import fire_patch_collection_event
+from sqlalchemy import or_, and_
 
 
 class Event:
@@ -73,13 +76,36 @@ class Event:
 
     @web.event('prompt_lib_prompt_published')
     def handle_prompt_publishing(self, context, event, payload: dict) -> None:
-        shared_owner_id = payload['shared_owner_id']
-        shared_id = payload['shared_id']
-        public_prompt_id = payload['public_prompt_id']
+        prompt_data = payload['prompt_data']
+        owner_id = prompt_data['owner_id']
+        collections = payload['collections']
         
-        # # get all related collections
-        # with db.with_project_schema_session(shared_owner_id) as session:
-        #     session.query(Collection).filter_by()
+        with db.with_project_schema_session(owner_id) as session:
+            collections = session.query(Collection).filter(
+                or_(
+                    *[ 
+                        and_(
+                            Collection.shared_id==collection['id'],
+                            Collection.shared_owner_id==collection['owner_id']
+                        ) for collection in collections
+                    ]
+                )
+            ).all()
+
+            for collection in collections:
+                prompts = deepcopy(collection.prompts)
+                prompts.append({
+                    "owner_id": owner_id,
+                    "id": prompt_data['id']
+                })
+                collection.prompts = prompts
+            session.commit()
+
+            for collection in collections:
+                fire_patch_collection_event(
+                    collection.to_json(), CollectionPatchOperations.add, prompt_data
+                )
+
 
 
 def group_by_project_id(data, data_type='dict'):

--- a/events/collections.py
+++ b/events/collections.py
@@ -6,7 +6,6 @@ from copy import deepcopy
 
 
 class Event:
-
     @web.event("prompt_lib_collection_updated")
     def handle_collection_updated(self, context, event, payload: dict):
         added_prompts = payload['added_prompts']
@@ -70,6 +69,17 @@ class Event:
             ]
             collection.prompts = clean_prompts
             session.commit()
+
+
+    @web.event('prompt_lib_prompt_published')
+    def handle_prompt_publishing(self, context, event, payload: dict) -> None:
+        shared_owner_id = payload['shared_owner_id']
+        shared_id = payload['shared_id']
+        public_prompt_id = payload['public_prompt_id']
+        
+        # # get all related collections
+        # with db.with_project_schema_session(shared_owner_id) as session:
+        #     session.query(Collection).filter_by()
 
 
 def group_by_project_id(data, data_type='dict'):

--- a/models/all.py
+++ b/models/all.py
@@ -6,7 +6,7 @@ from pylon.core.tools import log
 
 from .enums.all import PromptVersionStatus, PromptVersionType, MessageRoles
 from sqlalchemy import Integer, String, DateTime, func, ForeignKey, JSON, Table, Column, UniqueConstraint, MetaData
-from sqlalchemy.orm import Mapped, mapped_column, relationship, backref
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 
 class Prompt(db_tools.AbstractBaseMixin, db.Base):
@@ -117,7 +117,10 @@ PromptVersionTagAssociation = Table(
 
 class Collection(db_tools.AbstractBaseMixin, db.Base):
     __tablename__ = "prompt_collections"
-    __table_args__ = ({"schema": c.POSTGRES_TENANT_SCHEMA},)
+    __table_args__ = (
+        UniqueConstraint('shared_owner_id', 'shared_id', name='_version_shared_origin'),
+        {"schema": c.POSTGRES_TENANT_SCHEMA},
+    )
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     name: Mapped[str] = mapped_column(String, nullable=False)
     description: Mapped[str] = mapped_column(String, nullable=True)
@@ -126,3 +129,6 @@ class Collection(db_tools.AbstractBaseMixin, db.Base):
     prompts: Mapped[dict] = mapped_column(JSON, nullable=True)
     # ALTER TABLE carrier."P_1".prompt_collections ADD COLUMN created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
     created_at: Mapped[datetime] = mapped_column(DateTime, nullable=False, server_default=func.now())
+    # reference fields to origin 
+    shared_owner_id: Mapped[int] = mapped_column(Integer, nullable=True)
+    shared_id: Mapped[int] = mapped_column(Integer, nullable=True)

--- a/models/all.py
+++ b/models/all.py
@@ -118,7 +118,7 @@ PromptVersionTagAssociation = Table(
 class Collection(db_tools.AbstractBaseMixin, db.Base):
     __tablename__ = "prompt_collections"
     __table_args__ = (
-        UniqueConstraint('shared_owner_id', 'shared_id', name='_version_shared_origin'),
+        UniqueConstraint('shared_owner_id', 'shared_id', name='_collection_shared_origin'),
         {"schema": c.POSTGRES_TENANT_SCHEMA},
     )
     id: Mapped[int] = mapped_column(Integer, primary_key=True)

--- a/models/pd/base.py
+++ b/models/pd/base.py
@@ -72,7 +72,6 @@ class PromptVersionBaseModel(BaseModel):
     shared_id: Optional[int]
     shared_owner_id: Optional[int]
 
-
     class Config:
         orm_mode = True
 

--- a/models/pd/collections.py
+++ b/models/pd/collections.py
@@ -25,6 +25,8 @@ class CollectionModel(BaseModel):
     author_id: Optional[int]
     description: Optional[str]
     prompts: Optional[List[PromptIds]] = []
+    shared_id: Optional[int]
+    shared_owner_id: Optional[int]
 
 
 class PromptBaseModel(BaseModel):

--- a/utils/collections.py
+++ b/utils/collections.py
@@ -232,21 +232,21 @@ def remove_prompt_from_collection(collection, prompt_data: PromptIds):
     return get_detail_collection(collection)
 
 
-def fire_patch_collection_event(old_state, operartion, prompt_data):
+def fire_patch_collection_event(collection_data, operartion, prompt_data):
     if operartion == CollectionPatchOperations.add:
         removed_prompts = tuple()
-        added_prompts = [(prompt_data.owner_id, prompt_data.id)]
+        added_prompts = [(prompt_data['owner_id'], prompt_data['id'])]
     else:
         added_prompts = tuple()
-        removed_prompts = [(prompt_data.owner_id, prompt_data.id)]
+        removed_prompts = [(prompt_data['owner_id'], prompt_data['id'])]
 
     rpc_tools.EventManagerMixin().event_manager.fire_event(
         'prompt_lib_collection_updated', {
             "removed_prompts": removed_prompts,
             "added_prompts": added_prompts,
             "collection_data": {
-                "owner_id": old_state['owner_id'],
-                "id": old_state['id']
+                "owner_id": collection_data['owner_id'],
+                "id": collection_data['id']
             }
         }
     )
@@ -276,7 +276,7 @@ def patch_collection(project_id, collection_id, data: CollectionPatchModel):
             collection_data = collection.to_json()
             session.commit()
             fire_patch_collection_event(
-                collection_data, data.operation, prompt_data
+                collection_data, data.operation, prompt_data.dict()
             )
             return result
         return None

--- a/utils/publish_utils.py
+++ b/utils/publish_utils.py
@@ -122,9 +122,12 @@ class Publishing(rpc_tools.EventManagerMixin):
         with db.with_project_schema_session(self.public_id) as session:
             try:
                 prompt = self.get_public_prompt()
-                # new_prompt_created = False
+                new_prompt_created = False
+                prompt_collections = None
                 if not prompt:
-                    # new_prompt_created = True
+                    new_prompt_created = True
+                    prompt_collections = self.prompt_data['collections']
+                    self.prompt_data['collections'] = []
                     prompt = self._create_prompt(self.prompt_data)
                     session.flush()
 
@@ -132,8 +135,8 @@ class Publishing(rpc_tools.EventManagerMixin):
                 public_version = self._create_new_version(self.prompt_version_data, prompt, session)
                 session.commit()
                 self.public_version_id = public_version.id
-                # if new_prompt_created:
-                #     fire_public_prompt_created(prompt.to_json())
+                if new_prompt_created:
+                    fire_public_prompt_created(prompt.to_json(), prompt_collections)
             except Exception as e:
                 session.rollback()
                 return {"ok": False, "error": str(e)}
@@ -246,13 +249,12 @@ def delete_public_prompt_versions(prompt_owner_id, prompt_id, session):
         session.delete(version)
 
 
-def fire_public_prompt_created(shared_owner_id, shared_id, public_prompt_id):
+def fire_public_prompt_created(prompt_data, collections):
     rpc_tools.EventManagerMixin().event_manager.fire_event(
         "prompt_lib_prompt_published", 
         {
-            "shared_owner_id": shared_owner_id,
-            "shared_id": shared_id,
-            "public_prompt_id": public_prompt_id
+            "prompt_data": prompt_data,
+            "collections": collections,
         }
     )
 


### PR DESCRIPTION
How it was implemented:
1. When a collection is published, all prompts in the collection are also included in the public collection only if it was published as well
2. If one of the private prompts of the collection is published, then it will also be added to the public collection
3. If a public collection is deleted, then that collection is removed from the public prompts' collections field.