### PR TITLE
Filters, pagination to detail collection endpoint and other bug fixes

### DIFF
--- a/api/v1/export_import_collection.py
+++ b/api/v1/export_import_collection.py
@@ -30,7 +30,10 @@ class PromptLibAPI(api_tools.APIModeHandler):
     @api_tools.endpoint_metrics
     def get(self, project_id: int, collection_id: int = None, **kwargs):
         to_dail = 'to_dial' in request.args
-        result = collection_export(project_id, collection_id, to_dail)
+        try:
+            result = collection_export(project_id, collection_id, to_dail)
+        except Exception as e:
+            return {"ok": False, "error": str(e)}, 404
         if 'as_file' in request.args:
             file = BytesIO()
             data = json.dumps(result, ensure_ascii=False, indent=4)

--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -85,7 +85,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         return {
             'total': some_result['total'],
             'rows': [
-                json.loads(i.json(exclude={'status'}, exclude_unset=True))
+                json.loads(i.json(exclude={'status'}))
                 for i in parsed.prompts
             ]
         }, 200

--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -85,7 +85,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         return {
             'total': some_result['total'],
             'rows': [
-                json.loads(i.json(exclude={'status'}))
+                json.loads(i.json())
                 for i in parsed.prompts
             ]
         }, 200

--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -62,6 +62,10 @@ class PromptLibAPI(api_tools.APIModeHandler):
     )
     @api_tools.endpoint_metrics
     def get(self, project_id: int | None = None, **kwargs):
+        collection = {
+            "id": request.args.get('collection_id', type=int),
+            "owner_id": request.args.get('collection_owner_id', type=int)
+        }
         some_result = list_prompts_api(
             project_id=project_id,
             tags=request.args.get('tags'),
@@ -74,7 +78,8 @@ class PromptLibAPI(api_tools.APIModeHandler):
             my_liked=request.args.get('my_liked', False),
             trend_start_period=request.args.get('trend_start_period'),
             trend_end_period=request.args.get('trend_end_period'),
-            statuses=request.args.get('statuses')
+            statuses=request.args.get('statuses'),
+            collection=collection
         )
         parsed = MultiplePromptListModel(prompts=some_result['prompts'])
         return {

--- a/api/v1/public_prompts.py
+++ b/api/v1/public_prompts.py
@@ -43,7 +43,7 @@ class PromptLibAPI(api_tools.APIModeHandler):
         return {
             'total': some_result['total'],
             'rows': [
-                json.loads(i.json(exclude={'status'}, exclude_unset=True))
+                json.loads(i.json(exclude={'status'}))
                 for i in parsed.prompts
             ]
         }, 200

--- a/utils/export_import_utils.py
+++ b/utils/export_import_utils.py
@@ -28,17 +28,15 @@ def prompts_export_to_dial(project_id: int, prompt_id: int = None, session=None)
     prompts_to_export = []
     for prompt in prompts:
         prompt_data = prompt.to_json()
+        export_data = {**prompt_data}
         for version in prompt.versions:
-            export_data = {
-                'content': version.context or '',
-                **prompt_data
-            }
+            export_data['content'] = version.context or ''
             if version.model_settings:
                 export_data['model'] = DialModelImportModel(
                     id=version.model_settings.get('model', {}).get('name', '')
                     )
-            prompts_to_export.append(DialPromptImportModel(**export_data))
-
+        
+        prompts_to_export.append(DialPromptImportModel(**export_data))
     result = DialImportModel(prompts=prompts_to_export, folders=[])
     session.close()
 
@@ -85,7 +83,6 @@ def prompts_export(project_id: int, prompt_id: int = None, session=None) -> dict
         )
     )
     prompts: List[Prompt] = query.all()
-
     prompts_to_export = []
     for prompt in prompts:
         prompt_data = PromptExportModel.from_orm(prompt)

--- a/utils/export_import_utils.py
+++ b/utils/export_import_utils.py
@@ -48,6 +48,8 @@ def prompts_export_to_dial(project_id: int, prompt_id: int = None, session=None)
 def collection_export(project_id: int, collection_id: int, to_dail=False):
     with db.with_project_schema_session(project_id) as session:
         collection = session.query(Collection).get(collection_id)
+        if not collection:
+            raise Exception(f"Collection with id '{collection_id}' not found")
         grouped_prompts = group_by_project_id(collection.prompts)
         result_prompts = []
         for project_id, prompts in grouped_prompts.items():

--- a/utils/prompt_utils.py
+++ b/utils/prompt_utils.py
@@ -468,7 +468,8 @@ def list_prompts_api(
         my_liked: bool = False,
         trend_start_period: str | None = None,
         trend_end_period: str | None = None,
-        with_likes: bool = True
+        with_likes: bool = True,
+        collection: Optional[dict[str, int]] = None
 
 ):
     filters = []
@@ -493,6 +494,13 @@ def list_prompts_api(
                 Prompt.description.ilike(f"%{q}%")
             )
         )
+
+    if collection and collection.get('id') and collection.get('owner_id'):
+        collection_value = {
+            "id": collection['id'],
+            "owner_id": collection['owner_id']
+        }
+        filters.append(Prompt.collections.contains([collection_value]))
 
     trend_period = None
     if trend_start_period:

--- a/utils/publish_utils.py
+++ b/utils/publish_utils.py
@@ -333,6 +333,9 @@ def fire_prompt_deleted_event(project_id, prompt: dict):
         f'{prefix}_prompt_deleted', payload
     )
 
+    rpc_tools.EventManagerMixin().event_manager.fire_event(
+        "prompt_deleted", prompt
+    )
 
 def is_public_project(project_id: int = None):
     ai_project_id = get_public_project_id()


### PR DESCRIPTION
1. Filters by tag, author, and statuses added to detail collection endpoint
2. Event for prompt deleted added which removes that promt-related collections
3. Filtering by collection ID in prompt list endpoint
4. Adding back tags list to public_prompts and prompts endpoint
5. BugFix: export collection returns wrong content
6. import prompts should create variables, even if empty
