### PR TITLE
Advanced searching for prompts and bugxfix

### DIFF
--- a/api/v1/prompts.py
+++ b/api/v1/prompts.py
@@ -8,6 +8,7 @@ from tools import api_tools, config as c, db, auth
 from ...models.pd.create import PromptCreateModel
 from ...models.pd.detail import PromptDetailModel, PromptVersionDetailModel
 from ...models.pd.list import MultiplePromptListModel
+from ...models.pd.search import SearchDataModel
 
 from ...utils.constants import PROMPT_LIB_MODE
 from ...utils.create_utils import create_prompt
@@ -62,6 +63,13 @@ class PromptLibAPI(api_tools.APIModeHandler):
     )
     @api_tools.endpoint_metrics
     def get(self, project_id: int | None = None, **kwargs):
+        try:
+            payload = request.get_json()
+            search_data = payload.get("search_data")
+            SearchDataModel.validate(search_data)
+        except Exception:
+            search_data = None
+        
         collection = {
             "id": request.args.get('collection_id', type=int),
             "owner_id": request.args.get('collection_owner_id', type=int)
@@ -79,7 +87,8 @@ class PromptLibAPI(api_tools.APIModeHandler):
             trend_start_period=request.args.get('trend_start_period'),
             trend_end_period=request.args.get('trend_end_period'),
             statuses=request.args.get('statuses'),
-            collection=collection
+            collection=collection,
+            search_data=search_data
         )
         parsed = MultiplePromptListModel(prompts=some_result['prompts'])
         return {

--- a/api/v1/public_prompts.py
+++ b/api/v1/public_prompts.py
@@ -6,6 +6,7 @@ from tools import api_tools, config as c, db, auth
 
 from ...models.pd.list import MultiplePublishedPromptListModel
 from ...models.enums.all import PromptVersionStatus
+from ...models.pd.search import SearchDataModel
 
 from ...utils.constants import PROMPT_LIB_MODE
 from ...utils.prompt_utils import list_prompts_api
@@ -25,6 +26,13 @@ class PromptLibAPI(api_tools.APIModeHandler):
     )
     @api_tools.endpoint_metrics
     def get(self, *, project_id: int, **kwargs):
+        try:
+            payload = request.get_json()
+            search_data = payload.get("search_data")
+            SearchDataModel.validate(search_data)
+        except Exception:
+            search_data = None
+        
         some_result = list_prompts_api(
             project_id=project_id,
             tags=request.args.get('tags'),
@@ -37,7 +45,8 @@ class PromptLibAPI(api_tools.APIModeHandler):
             my_liked=request.args.get('my_liked', False),
             trend_start_period=request.args.get('trend_start_period'),
             trend_end_period=request.args.get('trend_end_period'),
-            statuses=[PromptVersionStatus.published]
+            statuses=[PromptVersionStatus.published],
+            search_data=search_data
         )
         parsed = MultiplePublishedPromptListModel(prompts=some_result['prompts'])
         return {

--- a/api/v1/search_requests.py
+++ b/api/v1/search_requests.py
@@ -1,0 +1,40 @@
+import json
+from flask import request
+from pylon.core.tools import log
+from tools import api_tools, auth, config as c
+from ...utils.constants import PROMPT_LIB_MODE
+from ...utils.searches import list_search_requests
+from ...models.pd.search import SearchRequestsListModel
+
+
+class PromptLibAPI(api_tools.APIModeHandler):
+    @auth.decorators.check_api({
+        "permissions": ["models.prompt_lib.search_requests.list"],
+        "recommended_roles": {
+            c.ADMINISTRATION_MODE: {"admin": True, "editor": True, "viewer": False},
+            c.DEFAULT_MODE: {"admin": True, "editor": True, "viewer": False},
+        }})
+    def get(self, project_id: int):
+        args = request.args
+        total, searches = list_search_requests(project_id, args)
+        parsed = SearchRequestsListModel(searches=searches)
+        return {
+            'total': total,
+            'rows': [
+                json.loads(i.json())
+                for i in parsed.searches
+            ]
+        }, 200
+
+
+class API(api_tools.APIBase):
+    url_params = api_tools.with_modes(
+        [
+            "<int:project_id>",
+        ]
+    )
+
+
+    mode_handlers = {
+        PROMPT_LIB_MODE: PromptLibAPI,
+    }

--- a/events/search.py
+++ b/events/search.py
@@ -1,0 +1,41 @@
+from pylon.core.tools import log, web
+
+from tools import db
+from ..models.all import SearchRequest, PromptTag
+
+
+class Event:
+    @web.event("prompt_lib_search_conducted")
+    def handler(self, context, event, payload: dict):
+        project_id = payload.get("project_id")
+        search_data = payload.get('search_data')
+        tag_ids = search_data.get("tag_ids", [])
+        keywords: list = search_data.get("keywords", [])
+        keywords.extend(keywords)
+
+        with db.with_project_schema_session(project_id) as session:
+            tags = session.query(PromptTag).filter(
+                PromptTag.id.in_(tag_ids)
+            ).all()
+            for tag in tags:
+                keywords.append(tag.name)
+
+            searches = session.query(SearchRequest).filter(
+                SearchRequest.search_keyword.in_(keywords)
+            )
+            # incrementing search counts
+            for search in searches:
+                search.count += 1
+            
+            # creating new searches
+            existing_searches = set(search.search_keyword for search in searches)
+            new_searches = set(keywords) - existing_searches
+            for keyword in new_searches:
+                new_search = SearchRequest(search_keyword=keyword)
+                session.add(new_search)
+            session.commit()
+
+
+            
+
+

--- a/models/all.py
+++ b/models/all.py
@@ -133,3 +133,14 @@ class Collection(db_tools.AbstractBaseMixin, db.Base):
     # reference fields to origin 
     shared_owner_id: Mapped[int] = mapped_column(Integer, nullable=True)
     shared_id: Mapped[int] = mapped_column(Integer, nullable=True)
+
+
+
+class SearchRequest(db_tools.AbstractBaseMixin, db.Base):
+    __tablename__ = "search_requests"
+    __table_args__ = (
+        {"schema": c.POSTGRES_TENANT_SCHEMA},
+    )
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    search_keyword: Mapped[str] = mapped_column(String, nullable=False)
+    count: Mapped[int] = mapped_column(Integer, nullable=False, default=1)

--- a/models/pd/list.py
+++ b/models/pd/list.py
@@ -79,6 +79,19 @@ class PublishedPromptListModel(PromptListModel):
     class Config:
         from_orm = True
 
+    @validator('is_liked')
+    def is_liked_field(cls, v):
+        if v is None:
+            return False
+        return v
+    
+
+    @validator('likes')
+    def likes_field(cls, v):
+        if v is None:
+            return 0
+        return v
+    
 
 class MultiplePromptListModel(BaseModel):
     prompts: List[PromptListModel]

--- a/models/pd/search.py
+++ b/models/pd/search.py
@@ -1,0 +1,20 @@
+from typing import List, Optional
+from pydantic import BaseModel
+
+
+class SearchRequestModel(BaseModel):
+    search_keyword: str
+    count: int
+
+    class Config:
+        orm_mode = True
+
+
+class SearchRequestsListModel(BaseModel):
+    searches: List[SearchRequestModel]
+
+
+
+class SearchDataModel(BaseModel):
+    keywords: Optional[List[str]]
+    tag_ids: Optional[List[int]]

--- a/module.py
+++ b/module.py
@@ -71,7 +71,8 @@ class Module(module.ModuleModel):
         from .models.all import (
             Prompt, PromptVersion,
             PromptTag, PromptMessage,
-            PromptVariable, PromptVersionTagAssociation
+            PromptVariable, PromptVersionTagAssociation,
+            SearchRequest,
         )
         project_list = self.context.rpc_manager.call.project_list()
         for i in project_list:

--- a/utils/collections.py
+++ b/utils/collections.py
@@ -61,6 +61,8 @@ def get_prompts_for_collection(collection_prompts: List[Dict[str, int]], only_pu
     filters = []
     offset = request.args.get("offset", 0, type=int)
     limit = request.args.get("limit", 10, type=int)
+    trend_period = request.args.get("trending_period")
+    my_liked = request.args.get('my_liked', False)
 
     if tags := request.args.get('tags'):
         # # Filtering parameters
@@ -102,6 +104,25 @@ def get_prompts_for_collection(collection_prompts: List[Dict[str, int]], only_pu
                     entity_name='prompt',
                 )
                 extra_columns.extend(new_columns)
+
+                if trend_period:
+                    prompt_query, new_columns = add_trending_likes(
+                        original_query=prompt_query,
+                        project_id=project_id,
+                        entity_name='prompt',
+                        trend_period=trend_period,
+                        filter_results=True
+                    )
+                    extra_columns.extend(new_columns)
+
+                prompt_query, new_columns = add_my_liked(
+                    original_query=prompt_query,
+                    project_id=project_id,
+                    entity_name='prompt',
+                    filter_results=my_liked
+                )
+                extra_columns.extend(new_columns)
+
                 # prompt_query = add_likes(prompt_query, project_id, 'prompt')
             q_result = prompt_query.all()
             project_prompts = list(set_columns_as_attrs(q_result, extra_columns))

--- a/utils/searches.py
+++ b/utils/searches.py
@@ -1,0 +1,20 @@
+from tools import db
+# from pylon.core.tools import log
+from ..models.all import SearchRequest
+from sqlalchemy import desc, asc
+
+
+
+def list_search_requests(project_id, args):
+    limit = args.get('limit', default=5, type=int)
+    offset = args.get('offset', default=0, type=int)
+    sort_order = args.get('sort_order', "desc")
+    sort_by = args.get('sort_by', "count")
+
+    with db.with_project_schema_session(project_id) as session:
+        query = session.query(SearchRequest)
+        total = query.count()
+        sort_fun = desc if sort_order == "desc" else asc
+        query = query.order_by(sort_fun(getattr(SearchRequest, sort_by)))
+        query = query.limit(limit).offset(offset)
+        return total, query.all()


### PR DESCRIPTION
This PR contains the following improvements:
1. Endpoint for tracking top search keywords
2. Event handler to update search keyword counts when prompts are searched
3. Filtering by tag name in tag list endpoint
4. Searching mechanism('OR' search) to search prompts by tags and keywords at the same time
5. Bugfix: is_liked being null in public collection detail endpoint